### PR TITLE
Feature/mobile cleanup

### DIFF
--- a/src/main/java/com/privalia/qa/specs/HookGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/HookGSpec.java
@@ -294,38 +294,25 @@ public class HookGSpec extends BaseGSpec {
             grid = "http://127.0.0.1:4723";
         }
 
-        if (ThreadProperty.get("browser") != null) {
-            Map<String, String> capabilitiesMap = mapper.readValue(b, Map.class);
-
-            //This capabilities are removed since they can cause problems when testing mobile apps
-            capabilitiesMap.remove("platform");
-            capabilitiesMap.remove("maxInstances");
-            capabilitiesMap.remove("seleniumProtocol");
-
-            //Assign all found capabilities found returned by the selenium node
-            for (Map.Entry<String, String> entry : capabilitiesMap.entrySet()) {
-                capabilities.setCapability(entry.getKey(), (Object) entry.getValue());
-            }
-        } else {
-            if (System.getProperty("app") != null) {
-                capabilities.setCapability(MobileCapabilityType.APP, System.getProperty("app"));
-            }
-            if (System.getProperty("platformName") != null) {
-                capabilities.setCapability(MobileCapabilityType.PLATFORM_NAME, System.getProperty("platformName"));
-            }
-            if (System.getProperty("udid") != null) {
-                capabilities.setCapability(MobileCapabilityType.UDID, System.getProperty("udid"));
-            }
-            if (System.getProperty("deviceName") != null) {
-                capabilities.setCapability(MobileCapabilityType.DEVICE_NAME, System.getProperty("deviceName"));
-            }
-            if (System.getProperty("platformVersion") != null) {
-                capabilities.setCapability(MobileCapabilityType.PLATFORM_VERSION, System.getProperty("platformVersion"));
-            }
-            if (System.getProperty("browserName") != null) {
-                capabilities.setCapability(MobileCapabilityType.BROWSER_NAME, System.getProperty("browserName"));
-            }
+        if (System.getProperty("app") != null) {
+            capabilities.setCapability(MobileCapabilityType.APP, System.getProperty("app"));
         }
+        if (System.getProperty("platformName") != null) {
+            capabilities.setCapability(MobileCapabilityType.PLATFORM_NAME, System.getProperty("platformName"));
+        }
+        if (System.getProperty("udid") != null) {
+            capabilities.setCapability(MobileCapabilityType.UDID, System.getProperty("udid"));
+        }
+        if (System.getProperty("deviceName") != null) {
+            capabilities.setCapability(MobileCapabilityType.DEVICE_NAME, System.getProperty("deviceName"));
+        }
+        if (System.getProperty("platformVersion") != null) {
+            capabilities.setCapability(MobileCapabilityType.PLATFORM_VERSION, System.getProperty("platformVersion"));
+        }
+        if (System.getProperty("browserName") != null) {
+            capabilities.setCapability(MobileCapabilityType.BROWSER_NAME, System.getProperty("browserName"));
+        }
+
 
         if (capabilities.getCapability("platformName") == null) {
             commonspec.getLogger().warn("No platformName capability found, using Android......");

--- a/src/main/java/com/privalia/qa/specs/HookGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/HookGSpec.java
@@ -289,7 +289,9 @@ public class HookGSpec extends BaseGSpec {
         String b = ThreadProperty.get("browser");
 
         if (grid == null) {
-            fail("Selenium grid not available. You must use -DSELENIUM_GRID");
+            this.getCommonSpec().getLogger().warn("Appium server not specified!");
+            this.getCommonSpec().getLogger().warn("Using SELENIUN_GRID=. Use VM argument -DSELENIUN_GRID=<url> to set the appium server");
+            grid = "http://127.0.0.1:4723";
         }
 
         if (ThreadProperty.get("browser") != null) {
@@ -361,7 +363,7 @@ public class HookGSpec extends BaseGSpec {
                 }
 
                 commonspec.getLogger().debug("Building IOSDriver with capabilities %s", capabilities.toJson().toString());
-                commonspec.setDriver(new IOSDriver(new URL("http://" + grid + "/wd/hub"), capabilities));
+                commonspec.setDriver(new IOSDriver(new URL(grid), capabilities));
                 break;
 
             default:

--- a/src/main/java/com/privalia/qa/specs/HookGSpec.java
+++ b/src/main/java/com/privalia/qa/specs/HookGSpec.java
@@ -323,7 +323,7 @@ public class HookGSpec extends BaseGSpec {
          * If you need to pass more or more specific capabilities, use -DCAPABILITIES=/path/to/capabilities.json
          */
         String[] generalCaps = {"automationName", "platformName", "platformVersion", "deviceName", "app", "otherApps", "browserName", "newCommandTimeout", "language",
-        "locale", "udid", "orientation", "autoWebview", "noReset", "fullReset", "eventTimings", "enablePerformanceLogging", "printPageSourceOnFindFailure", "clearSystemFiles"};
+            "locale", "udid", "orientation", "autoWebview", "noReset", "fullReset", "eventTimings", "enablePerformanceLogging", "printPageSourceOnFindFailure", "clearSystemFiles"};
         for (String cap : generalCaps) {
             if (System.getProperty(cap) != null) {
                 capabilities.setCapability(cap, System.getProperty(cap));
@@ -405,7 +405,7 @@ public class HookGSpec extends BaseGSpec {
         ObjectMapper mapper = new ObjectMapper();
         capsMap = mapper.readValue(Files.readAllBytes(Paths.get(filePath)), Map.class);
 
-        for (Map.Entry<String,Object> entry : capsMap.entrySet()) {
+        for (Map.Entry<String, Object> entry : capsMap.entrySet()) {
             capabilities.setCapability(entry.getKey(), entry.getValue());
         }
     }

--- a/src/test/java/com/privalia/qa/specs/HookGSpecTest.java
+++ b/src/test/java/com/privalia/qa/specs/HookGSpecTest.java
@@ -1,0 +1,34 @@
+package com.privalia.qa.specs;
+
+import org.openqa.selenium.MutableCapabilities;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+
+public class HookGSpecTest {
+
+    final  HookGSpec hgs  = new HookGSpec(null);
+
+    @Test
+    public void testWrongFilePath() throws IOException {
+
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("browserName", "chrome");
+        Assert.expectThrows(NoSuchFileException.class, () -> hgs.addCapabilitiesFromFile("hola", capabilities));
+
+    }
+
+    @Test
+    public void testMerge() throws IOException {
+
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("browserName", "chrome");
+        hgs.addCapabilitiesFromFile("src/test/resources/capabilities.json", capabilities);
+        Assert.assertEquals(capabilities.getCapability("browserName"),"chrome");
+        Assert.assertNotNull(capabilities.getPlatform());
+        Assert.assertNotNull(capabilities.getCapability("chromeOptions"));
+        Assert.assertEquals(capabilities.getPlatform().name(), "ANY");
+    }
+}

--- a/src/test/resources/capabilities.json
+++ b/src/test/resources/capabilities.json
@@ -1,0 +1,8 @@
+{
+  "platform": "ANY",
+  "acceptSslCerts": true,
+  "chromeOptions": {
+    "args": ["start-fullscreen", "incognito", "disable-extensions", "test-type"],
+    "w3c": false
+  }
+}

--- a/src/test/resources/capabilities.json
+++ b/src/test/resources/capabilities.json
@@ -1,6 +1,6 @@
 {
   "platform": "ANY",
-  "acceptSslCerts": true,
+  "browserName": "chrome",
   "chromeOptions": {
     "args": ["start-fullscreen", "incognito", "disable-extensions", "test-type"],
     "w3c": false

--- a/src/test/resources/features/mobile.feature
+++ b/src/test/resources/features/mobile.feature
@@ -2,16 +2,13 @@
 @mobile
 Feature: Running tests in mobile devices
 
-    This feature provides an overview of the available steps for testing native mobile apps (android & ios).
-    Notice that the @mobile annotation at the beginning of the feature is NECESSARY to bootstrap the Appium driver
+  This feature provides an overview of the available steps for testing native mobile apps (android & ios).
+  Notice that the @mobile annotation at the beginning of the feature is NECESSARY to bootstrap the Appium driver
 
-    You can connect your mobile device as a node in a selenium grid using Appium, and run this feature like this
-    (assuming grid is running in localhost:4444):
-    mvn verify -Dit.test=com.privalia.qa.specs.MobileGIT -DSELENIUM_GRID=localhost:4444
+  Run this test like this: mvn verify -Dit.test=com.privalia.qa.specs.MobileGIT
 
-    Or you can directly start an Appium server (no grid required) and run this feature like this (assuming Appium
-    server is running in localhost:4723)
-    mvn verify -Dit.test=com.privalia.qa.specs.MobileGIT -DSELENIUM_NODE=localhost:4723
+  If not specified, GingerSpec will automatically use http://localhost:4723 as the url of the Appium server. You can
+  specify any other url using -DSELENIUM_GRID=<url> when running
 
   Scenario: Opening an closing the app
     Given I open the application

--- a/src/test/resources/mobile_capabilities.json
+++ b/src/test/resources/mobile_capabilities.json
@@ -1,0 +1,6 @@
+{
+  "app": "https://github.com/appium/appium/raw/master/sample-code/apps/ApiDemos-debug.apk",
+  "platformName": "Android",
+  "automationName": "UiAutomator2",
+  "deviceName": "My android phone"
+}


### PR DESCRIPTION
- Scenarios that make use of the @mobile tag will try to use http://localhost:4723/wd/hub as default if not specified via -DSELENIUM_GRID
- All references to browser variable was removed, and selenium and appium runner classes will no longer make use of the special constructor.
- The user can now set the capabilities using and external json file via -DCAPABILITIES=/path/to/capabilities.json. This will only work when using @mobile or when using @web through a selenium grid (no for local executions)
- Improved several javadoc comments